### PR TITLE
Ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 results
 __pycache__
+**/.DS_Store


### PR DESCRIPTION
This may or not matter to you, @everythingfunctional. I do most of my work on macOS. I seem to be unable to keep my Mac from littering the trees with `.DS_Store` files.

Can we add them to the `.gitignore`?