### PR TITLE
more common executable name

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """
 This is the entry point for running the compiler test framework.
 """


### PR DESCRIPTION
"python" might point to python 2 or might not be available at all. https://askubuntu.com/questions/1296790

closes #2 